### PR TITLE
[WORKAROUND] Export a browser-friendly UMD build

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ yarn add chartjs-plugin-tailwindcss-colors # or npm install
 [CDN](https://www.jsdelivr.com/package/npm/chartjs-plugin-tailwindcss-colors):
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-tailwindcss-colors@<version>/dist/index.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-tailwindcss-colors@<version>/dist/plugin.umd.min.js"></script>
 
 <!-- or as an ESM -->
 <script type="module">

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "description": "Colorize your Chart.js components using TailwindCSS!",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/main.js",
-  "module": "dist/main.esm.js",
+  "umd": "dist/plugin.umd.js",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
   "types": "dist/types.d.ts",
   "files": [
     "dist"
@@ -41,6 +42,24 @@
     "plugin",
     "parser"
   ],
+  "targets": {
+    "main": {
+      "context": "node",
+      "isLibrary": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "umd": {
+      "context": "browser",
+      "outputFormat": "global",
+      "isLibrary": false,
+      "optimize": false,
+      "engines": {
+        "browsers": "> 0.5%, last 2 versions, not dead"
+      }
+    }
+  },
   "dependencies": {
     "color-name": "^1.1.4",
     "lodash.get": "^4.4.2",
@@ -68,6 +87,7 @@
     "jest-environment-jsdom": "^29.4.1",
     "parcel": "^2.8.3",
     "prettier": "^2.6.2",
+    "process": "^0.11.10",
     "tailwindcss": "^3.2.4",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import twColorsPlugin from "./plugin"
 
-// https://gist.github.com/ebidel/3201b36f59f26525eb606663f7b487d0?permalink_comment_id=4102094#gistcomment-4102094
+// https://gist.github.com/ebidel/3201b36f59f26525eb606663f7b487d0#gistcomment-4102094
 function hasModuleSupport() {
   if ("supports" in HTMLScriptElement) {
     return HTMLScriptElement.supports("module")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,23 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import twColorsPlugin from "./plugin"
+
+// https://gist.github.com/ebidel/3201b36f59f26525eb606663f7b487d0?permalink_comment_id=4102094#gistcomment-4102094
+function hasModuleSupport() {
+  if ("supports" in HTMLScriptElement) {
+    return HTMLScriptElement.supports("module")
+  }
+  return "noModule" in document.createElement("script")
+}
+
+// Since Parcel v2 doesn't have proper support for global exports yet,
+// manually attach the plugin to the `document` object as a workaround
+// @see https://github.com/parcel-bundler/parcel/discussions/5583
+// @see https://github.com/parcel-bundler/parcel/issues/7312
+// @see https://github.com/parcel-bundler/parcel/pull/7240
+// @see https://v1.parceljs.org/cli.html#expose-modules-as-umd
+if (typeof window !== "undefined" && !hasModuleSupport()) {
+  // @ts-ignore
+  window.twColorsPlugin = twColorsPlugin
+}
 
 export default twColorsPlugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ function hasModuleSupport() {
   return "noModule" in document.createElement("script")
 }
 
-// Since Parcel v2 doesn't have proper support for global exports yet,
-// manually attach the plugin to the `document` object as a workaround
+// Since Parcel v2 doesn't have proper support for global expose yet,
+// manually attach the plugin to the `window` object as a workaround
 // @see https://github.com/parcel-bundler/parcel/discussions/5583
 // @see https://github.com/parcel-bundler/parcel/issues/7312
 // @see https://github.com/parcel-bundler/parcel/pull/7240

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,13 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import twColorsPlugin from "./plugin"
 
-// https://gist.github.com/ebidel/3201b36f59f26525eb606663f7b487d0#gistcomment-4102094
-function hasModuleSupport() {
-  if ("supports" in HTMLScriptElement) {
-    return HTMLScriptElement.supports("module")
-  }
-  return "noModule" in document.createElement("script")
-}
-
 // Since Parcel v2 doesn't have proper support for global expose yet,
 // manually attach the plugin to the `window` object as a workaround
 // @see https://github.com/parcel-bundler/parcel/discussions/5583
 // @see https://github.com/parcel-bundler/parcel/issues/7312
 // @see https://github.com/parcel-bundler/parcel/pull/7240
 // @see https://v1.parceljs.org/cli.html#expose-modules-as-umd
-if (typeof window !== "undefined" && !hasModuleSupport()) {
+if (typeof window !== "undefined") {
   // @ts-ignore
   window.twColorsPlugin = twColorsPlugin
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4768,6 +4768,11 @@ pretty-format@^29.4.3:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"


### PR DESCRIPTION
This is just a workaround for now until either one of these things happen:

- Parcel implements either per-target aliasing and/or port v1 `--global` flag (and also per-target support) to v2
- I finally decide to migrate everything to Rollup (I already have a branch ready, but there are some teeny-tiny issues with it that must be addressed first)

Note that, unfortunately, this _will_ still bundle the (currently) 4 dependencies in `package.json` and will result to ~136kb minified.

Semi-fixes #16.