### PR TITLE
fix(deps): remove `resolveConfig` from umd bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
   },
   "dependencies": {
     "color-name": "^1.1.4",
-    "lodash.get": "^4.4.2",
-    "lodash.set": "^4.3.2",
+    "lodash": "^4.17.21",
     "tiny-invariant": "^1.3.1"
   },
   "devDependencies": {
@@ -62,8 +61,7 @@
     "@tsconfig/recommended": "^1.0.3",
     "@types/color-name": "^1.1.3",
     "@types/jest": "^29.5.11",
-    "@types/lodash.get": "^4.4.9",
-    "@types/lodash.set": "^4.3.9",
+    "@types/lodash": "^4.14.202",
     "@types/pixelmatch": "^5.2.6",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -8,21 +8,19 @@ import typescript from "rollup-plugin-ts"
 
 import pkg from "./package.json" assert { type: "json" }
 
+const author = pkg.author.replaceAll(/ <[^>]+>/g, "")
 const banner = `/*!
  * ${pkg.name} v${pkg.version}
  * ${pkg.homepage}
- * (c) ${new Date().getFullYear()} ${pkg.author.replaceAll(
-  / <[^>]+>/g,
-  ""
-)} and ${pkg.name} Contributors
+ * (c) ${new Date().getFullYear()} ${author} and Contributors
  * Released under the MIT License
  */`
 
 const external: ExternalOption = [
   "chart.js",
   "tailwindcss/resolveConfig",
-  "lodash.get",
-  "lodash.set",
+  "lodash/get",
+  "lodash/set",
   "tiny-invariant",
   "color-name",
 ]
@@ -43,7 +41,7 @@ export default defineConfig([
       globals,
       sourcemap: true,
     },
-    external: external.slice(0, 1),
+    external: external.slice(0, 2),
     plugins: [
       typescript({
         tsconfig: (resolved) => ({

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,8 +1,8 @@
 import type { Plugin } from "chart.js"
 import type { Config as TailwindConfig } from "tailwindcss"
 
-import get from "lodash.get"
-import set from "lodash.set"
+import get from "lodash/get"
+import set from "lodash/set"
 
 import type { ParsableOptions, ValidValues } from "./types"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,21 +980,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash.get@^4.4.9":
-  version "4.4.9"
-  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.9.tgz#6390714bf688321d9a445cbc8e90220635649713"
-  integrity sha512-J5dvW98sxmGnamqf+/aLP87PYXyrha9xIgc2ZlHl6OHMFR2Ejdxep50QfU0abO1+CH6+ugx+8wEUN1toImAinA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.set@^4.3.9":
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.9.tgz#55d95bce407b42c6655f29b2d0811fd428e698f0"
-  integrity sha512-KOxyNkZpbaggVmqbpr82N2tDVTx05/3/j0f50Es1prxrWB0XYf9p3QNxqcbWb7P1Q9wlvsUSlCFnwlPCIJ46PQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
+"@types/lodash@^4.14.202":
   version "4.14.202"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.202.tgz#f09dbd2fb082d507178b2f2a5c7e74bd72ff98f8"
   integrity sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==
@@ -3603,11 +3589,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
-
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -3617,11 +3598,6 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
 
 lodash@^4.17.21:
   version "4.17.21"


### PR DESCRIPTION
Forgot to include `tailwindcss/resolveConfig` in the `external` for the UMD bundle. This put a ton of redundant code in the browser. My bad!

Using the `lodash` package directly since per-method packages are [deprecated](https://lodash.com/per-method-packages). It also helped shaved off some extra bits.